### PR TITLE
Add an unprivileged user `developer` to docker app containers

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -17,6 +17,13 @@ RUN apk add --update --no-cache \
   nodejs-current \
   yarn
 
+ARG USERNAME=developer
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN addgroup --gid $USER_GID $USERNAME &&\
+    adduser --shell /bin/bash --disabled-password --uid $USER_UID --ingroup $USERNAME $USERNAME 
+
 WORKDIR /app
 
 RUN yarn install --check-files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ x-database-credentials: &database_credentials
   ZANTOP_DATABASE_USER: zantop
   ZANTOP_DATABASE_PASSWORD: zantop
 x-app-config: &app_config
+  user: "developer"
   image: "zantop"
   build:
     context: .


### PR DESCRIPTION
In linux the docker containers execute all the commands as root by default. That means that we can end up with some files and `directorie` that belong to the root user and group after running some commands in them (ex: `./log`)

To fix this we add a user `developer` with the same UID and GID as the user of the host machine (usually 1000 in UNIX like systems)